### PR TITLE
Implement `Pod` for `UserContext` for other architectures

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -1,3 +1,5 @@
+use pod::Pod;
+
 #[cfg(target_os = "linux")]
 mod fncall;
 #[cfg(any(target_os = "none", target_os = "uefi"))]
@@ -9,7 +11,7 @@ pub use fncall::*;
 pub use trap::*;
 
 /// Saved registers on a trap.
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Pod, Eq, PartialEq)]
 #[repr(C)]
 pub struct UserContext {
     /// Trap num: Source and Kind
@@ -30,7 +32,7 @@ pub struct UserContext {
 }
 
 /// General registers
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Pod, Eq, PartialEq)]
 #[repr(C)]
 pub struct GeneralRegs {
     pub x1: usize,

--- a/src/arch/mipsel/trap.rs
+++ b/src/arch/mipsel/trap.rs
@@ -1,4 +1,5 @@
 use core::arch::{asm, global_asm};
+use pod::Pod;
 
 global_asm!(include_str!("trap.S"));
 
@@ -59,7 +60,7 @@ pub struct TrapFrame {
 }
 
 /// Saved registers on a trap.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Pod)]
 #[repr(C)]
 pub struct UserContext {
     /// TLS
@@ -108,7 +109,7 @@ impl UserContext {
 }
 
 /// General registers
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Pod)]
 #[repr(C)]
 pub struct GeneralRegs {
     pub hi: usize,

--- a/src/arch/riscv/trap.rs
+++ b/src/arch/riscv/trap.rs
@@ -1,4 +1,5 @@
 use core::arch::{asm, global_asm};
+use pod::Pod;
 
 #[cfg(target_arch = "riscv32")]
 global_asm!(
@@ -76,7 +77,7 @@ pub struct TrapFrame {
 }
 
 /// Saved registers on a trap.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Pod)]
 #[repr(C)]
 pub struct UserContext {
     /// General registers
@@ -117,7 +118,7 @@ impl UserContext {
 }
 
 /// General registers
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Pod)]
 #[repr(C)]
 pub struct GeneralRegs {
     pub zero: usize,


### PR DESCRIPTION
Implement `Pod` for `UserContext` and `GeneralRegs` for other architectures, keeping consistency with x86.